### PR TITLE
Do not allow trailing `.tar.gz` to be included in version string extracted by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
       depNameTemplate: "cisagov/guacscanner",
       managerFilePatterns: ["/^src/Pipfile$/"],
       matchStrings: [
-        "cisagov/guacscanner/archive/(?<currentValue>\\S+)", // src/Pipfile
+        "cisagov/guacscanner/archive/(?<currentValue>\\S+).tar.gz",
       ],
       versioningTemplate: "semver-coerced", // handles the leading `v`
     },


### PR DESCRIPTION
## 🗣 Description ##

This pull request tweaks a regex so that a trailing `.tar.gz` is no longer included as part of the version string matched by Renovate.

## 💭 Motivation and context ##

The configuration as it was did not extract the current version correctly.

## 🧪 Testing ##

I ran `LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset` locally with these new changes and they appear to work.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.